### PR TITLE
WYSIWYG feedback as commands are typed

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,14 +9,24 @@ import (
 	// "flag" TODO: Implement flags for file and burst modes
 	"fmt"
 	"os"
-	"strings"
+	"bytes"
+	"strconv"
+	"syscall"
 
 	"log"
 
 	"runtime/pprof"
 
-	"gopkg.in/readline.v1"
 	cli "gopkg.in/urfave/cli.v1"
+	"github.com/pkg/term/termios"  // just for portable Tc[gs]etattr
+)
+
+const (
+	esc = "\x1b"
+)
+
+var (
+	col byte  // column last typed at on screen
 )
 
 // This function starts an interpertor
@@ -161,16 +171,12 @@ func loadInteractive(m *machine) {
 	// given_files := flag.Bool("f", false, "Sets the rest of the arguments to list of files")
 	// Run command stuff here.
 
-	rl, err := readline.NewEx(&readline.Config{
-		Prompt:          ">> ",
-		HistoryFile:     "/tmp/readline.tmp",
-		InterruptPrompt: "^C",
-		EOFPrompt:       "exit",
-	})
+	in, err := syscall.Open("/dev/tty", syscall.O_RDONLY, 0)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, "error opening terminal")
 		return
 	}
+	defer syscall.Close(in)
 
 	fmt.Fprintln(
 		os.Stderr,
@@ -178,17 +184,27 @@ func loadInteractive(m *machine) {
 Independent
 Source
 Code`)
+
+	var orig_tios syscall.Termios
+	err = termios.Tcgetattr(uintptr(in), &orig_tios)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error saving terminal settings")
+		return
+	}
+	defer termios.Tcsetattr(uintptr(in), termios.TCSAFLUSH, &orig_tios)
+
+	// minimal switch to raw mode
+	tios := orig_tios
+	tios.Lflag &^= syscall.ICANON
+	termios.Tcsetattr(uintptr(in), termios.TCSAFLUSH, &tios)
+
+	// interactive loop
 	numEntries := 0
 	for {
-		// fmt.Print(">> ")
-		line, err := rl.Readline()
-		if strings.TrimSpace(line) == "exit" {
-			fmt.Fprintln(os.Stderr, "Exiting")
-			return
-		}
+		fmt.Print(">> ");  col = 3
+		line, err := readCommand(in, m)
 		if err == io.EOF {
-			fmt.Fprintln(os.Stderr, "Exiting program")
-			return
+			break
 		}
 		if err != nil {
 			panic(err)
@@ -212,5 +228,127 @@ Code`)
 			fmt.Println(val.String(), fmt.Sprint("<", val.Type(), ">"))
 		}
 	}
+}
 
+func readCommand(in int, m *machine) (string, error) {
+	buf := new(bytes.Buffer)
+	for {
+		b, err := readByte(in)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "error reading")
+			return "", err
+		}
+		if b[0] == /*ctrl-d*/4 {
+			return "", io.EOF  // exit
+		}
+		if b[0] == /*ctrl-u*/21 {
+			clear_line()
+			start_of_line()
+			fmt.Print(">> ");  col = 3
+			buf.Truncate(0)
+			continue
+		}
+		col++  // messes up on non-printing characters
+		if b[0] == /*backspace*/127 {
+			if buf.Len() > 0 {
+				left(2)  // undo print of backspace code
+				left(1)  // perform backspace
+				clear_right()
+				col -= 2  // undo backspace and previous character
+				buf.Truncate(buf.Len()-1)
+			}
+		}
+		if strconv.IsPrint(rune(b[0])) {
+			buf.Write(b)
+		}
+		if b[0] == '\r' || b[0] == '\n' {
+			break
+		}
+		execute_print_and_restore_cursor(*m, buf.String())
+	}
+	return buf.String(), nil
+}
+
+func execute_print_and_restore_cursor(m_copy machine, partial string) {
+	m_copy.executeString(partial+"\n", codePosition{})
+	var temporary_lines byte = 0
+	start_of_next_line();  temporary_lines++
+	clear_screen_below()
+	fmt.Println("Data Stack:");  temporary_lines++
+	for _, val := range m_copy.values {
+		fmt.Println(val.String(), fmt.Sprint("<", val.Type(), ">"));  temporary_lines++
+	}
+	up(temporary_lines);  right(col)
+}
+
+func readByte(in int) ([]byte, error) {
+	b := make([]byte, 1)
+	_, err := syscall.Read(in, b)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// some vt100 escape sequences (http://www.uqac.ca/flemieux/PRO100/VT100_Escape_Codes.html)
+
+func move_cursor(x, y int) {
+	os.Stdout.Write([]byte(fmt.Sprint(esc,"[",x,";",y,"H")))
+}
+
+// 256-color mode
+func color(c byte) {
+	os.Stdout.Write([]byte(fmt.Sprint(esc,"[38;5;",c,"m")))
+}
+func bg(c byte) {
+	os.Stdout.Write([]byte(fmt.Sprint(esc,"[48;5;",c,"m")))
+}
+
+func up(n byte) {
+	os.Stdout.Write([]byte(fmt.Sprint(esc,"[",n,"A")))
+}
+
+func down(n byte) {  // doesn't scroll
+	os.Stdout.Write([]byte(fmt.Sprint(esc,"[",n,"B")))
+}
+
+func left(n byte) {
+	os.Stdout.Write([]byte(fmt.Sprint(esc,"[",n,"D")))
+}
+
+func right(n byte) {
+	os.Stdout.Write([]byte(fmt.Sprint(esc,"[",n,"C")))
+}
+
+func clear_right() {
+	os.Stdout.Write([]byte(fmt.Sprint(esc,"[K")))
+}
+
+func clear_line() {
+	os.Stdout.Write([]byte(fmt.Sprint(esc,"[2K")))
+}
+
+func start_of_next_line() {
+	os.Stdout.Write([]byte("\n"))
+}
+
+func start_of_line() {
+	start_of_next_line()
+	up(1)
+}
+
+func clear_screen() {
+	os.Stdout.Write([]byte(fmt.Sprint(esc,"[2J")))
+}
+
+func clear_screen_below() {
+	os.Stdout.Write([]byte(fmt.Sprint(esc,"[0J")))
+}
+
+// no good after scroll
+func save_cursor() {
+	os.Stdout.Write([]byte(fmt.Sprint(esc,"7")))
+}
+func restore_cursor() {
+	os.Stdout.Write([]byte(fmt.Sprint(esc,"8")))
 }


### PR DESCRIPTION
Unlike most such implementations around, this one minimally switches to
raw mode. In particular, ctrl-c is still handled by the terminal, and the
terminal is still responsible for echoing characters to screen. That echoing
may be a bad idea; see the backspace handling.

Manual testing:
- type '1 2 + 3 *' with the session starting at the bottom of screen
    (ie. needing to scroll)
- type '1 2 + 3 *' with the session not needing to scroll
- backspace over the command

Not yet working:
- multi-word commands like 'swap'. WYSIWYG state is messed up.
- typing '['. Causes segfault and I don't understand why.

Drops readline.